### PR TITLE
Ignore missing columns in reporter

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -13,13 +13,11 @@ class Reporter {
       total += messages.length
 
       output += chalk.underline(filename) + '\n'
-      output += table(messages.map((msg) => {
-        return [
-          '',
-          `${msg.line}:${msg.column}`,
-          msg.msg
-        ]
-      }))
+      output += table(messages.map((msg) => [
+        '',
+        `${msg.line}${msg.column != null ? `:${msg.column}` : ''}`,
+        msg.msg
+      ]))
 
       output += '\n\n'
     }


### PR DESCRIPTION
Prevents rules that do not specify columns from outputting as `<LINE>:undefined`